### PR TITLE
Fix PHP 8.2 compatibility in GambitManager

### DIFF
--- a/src/Search/GambitManager.php
+++ b/src/Search/GambitManager.php
@@ -64,6 +64,7 @@ class GambitManager
      */
     protected function explode($query)
     {
+        $query = $query ?? '';
         return str_getcsv($query, ' ');
     }
 


### PR DESCRIPTION
Relevant: https://discuss.flarum.org/d/5682-friendsofflarum-user-directory/349
Changes proposed in this pull request:
This pull request addresses a compatibility issue with PHP 8.2 in the GambitManager class. Specifically, it modifies the handling of potentially null values in the str_getcsv function call on line 67. The change ensures that a default empty string is used if $query is null, which prevents PHP 8.2 deprecation warnings and potential errors related to the str_getcsv function.


Code Changes:

File: src/Search/GambitManager.php
Original Line: return str_getcsv($query, ' ');
Updated Line: $query = $query ?? ''; return str_getcsv($query, ' ');
Reviewers should focus on:

Verify that the proposed change correctly handles null values for the $query variable and does not introduce any new issues.
Ensure that this change is compatible with PHP 8.2 and does not affect functionality for previous PHP versions.
Screenshot

<!-- No visual changes are applicable to this fix. -->
QA

Ensure that the application no longer throws deprecation warnings related to str_getcsv when running on PHP 8.2.
Confirm that the GambitManager class functions as expected without any regression.

**Necessity**

- [ x] Has the problem that is being solved here been clearly explained?
- [x ] If applicable, have various options for solving this problem been considered?
- [ x] For core PRs, does this need to be in core, or could it be in an extension?
- [x ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ x] Frontend changes: tested on a local Flarum installation.
- [x ] Backend changes: tests are green (run `composer test`).
- [ x] Core developer confirmed locally this works as intended.
- [x ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
