### PR TITLE
Allow gd or imagick image extensions

### DIFF
--- a/src/Filesystem/FilesystemServiceProvider.php
+++ b/src/Filesystem/FilesystemServiceProvider.php
@@ -72,7 +72,7 @@ class FilesystemServiceProvider extends AbstractServiceProvider
             $config = $this->container->make(Config::class);
 
             $intervention = $config->offsetGet('intervention');
-            $driver = Arr::get($intervention, 'driver', self::INTERVENTION_DRIVERS['gd']);
+            $driver = Arr::get($intervention, 'driver', self::INTERVENTION_DRIVERS['imagick']);
 
             // Check that the imagick library is actually available, else default back to gd.
             if ($driver === self::INTERVENTION_DRIVERS['imagick'] && ! extension_loaded(self::INTERVENTION_DRIVERS['imagick'])) {

--- a/src/Install/Installation.php
+++ b/src/Install/Installation.php
@@ -106,7 +106,7 @@ class Installation
             new Prerequisite\PhpVersion('7.2.0'),
             new Prerequisite\PhpExtensions([
                 'dom',
-                'gd',
+                'gd|imagick',
                 'json',
                 'mbstring',
                 'openssl',

--- a/src/Install/Prerequisite/PhpExtensions.php
+++ b/src/Install/Prerequisite/PhpExtensions.php
@@ -24,6 +24,15 @@ class PhpExtensions implements PrerequisiteInterface
     {
         return (new Collection($this->extensions))
             ->reject(function ($extension) {
+                if (strpos($extension, '|') !== false) {
+                    return (bool) count(array_filter(
+                        explode('|', $extension),
+                        function ($currentExtension) {
+                            return extension_loaded($currentExtension);
+                        }
+                    ));
+                }
+
                 return extension_loaded($extension);
             })->map(function ($extension) {
                 return [


### PR DESCRIPTION
<!--
Enable imagick
-->

**Fixes #0000**

**Changes proposed in this pull request:**
This changes do not affect in any way image upload.
I tested with avatar uploaded.
Since the fallback is gd, the default driver should be imagick 
(Reffer to src/Filesystem/FilesystemServiceProvider.php)

PHP works with both gd and imagick. I don't see point in limitations of gd.
Actually, flarum don't use gd especially, i don't see any image manipulation that imagick can't do it.

**Reviewers should focus on:**
Image uploads.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
